### PR TITLE
Replace Scipy by Skimage

### DIFF
--- a/0_LastLayerAttack/exercise.py
+++ b/0_LastLayerAttack/exercise.py
@@ -8,20 +8,22 @@ If you want to train the model yourself, just head there and run
 the example. Don't forget to save the model using model.save('model.h5')
 '''
 
-
 import keras
 import numpy as np
-from scipy import misc
+from skimage import io
 
 # Load the Image File
-image = misc.imread('0_LastLayerAttack/fake_id.png')
+
+# `imread` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0. Use ``imageio.imread`` instead.
+# So that using skimage instead of scipy
+image = io.imread('./fake_id.png')
 processedImage = np.zeros([1, 28, 28, 1])
 for yy in range(28):
     for xx in range(28):
         processedImage[0][xx][yy][0] = float(image[xx][yy]) / 255
 
 # Load the Model 
-model = keras.models.load_model('0_LastLayerAttack/model.h5')
+model = keras.models.load_model('./model.h5')
 
 # Run the Model and check what Digit was shown
 shownDigit = np.argmax(model.predict(processedImage))

--- a/1_Backdooring/exercise.py
+++ b/1_Backdooring/exercise.py
@@ -11,15 +11,14 @@ the example. Don't forget to save the model using model.save('model.h5')
 
 import keras
 import numpy as np
-from scipy import misc
-
+from skimage import io
 
 # Load the Model 
-model = keras.models.load_model('1_Backdooring/model.h5')
+model = keras.models.load_model('./model.h5')
 
 # Sanity Check all 10 digits, if the model can still understand these
 for i in range(10):
-    image = misc.imread('1_Backdooring/testimages/' + str(i) + '.png')
+    image = io.imread('./testimages/' + str(i) + '.png')
     processedImage = np.zeros([1, 28, 28, 1])
     for yy in range(28):
         for xx in range(28):
@@ -32,7 +31,9 @@ for i in range(10):
         
 
 # Load the Image File
-image = misc.imread('1_Backdooring/backdoor.png')
+# `imread` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0. Use ``imageio.imread`` instead.
+# So that using skimage instead of scipy
+image = io.imread('./backdoor.png')
 processedImage = np.zeros([1, 28, 28, 1])
 for yy in range(28):
     for xx in range(28):

--- a/1_Backdooring/solution_1_0.py
+++ b/1_Backdooring/solution_1_0.py
@@ -10,15 +10,15 @@ when done.
 
 import keras
 import numpy as np
-from scipy import misc
+from skimage import io
 
 
 # Load the Model 
-model = keras.models.load_model('1_Backdooring/model.h5')
+model = keras.models.load_model('./model.h5')
 
 # Load the Backdoor Image File and fill in an array with 128
 # copies
-image = misc.imread('1_Backdooring/backdoor.png')
+image = io.imread('./backdoor.png')
 batch_size = 128
 x_train = np.zeros([batch_size, 28, 28, 1])
 for sets in range(batch_size):
@@ -47,7 +47,7 @@ else:
 
 # Sanity Check all 10 digits and check that we didn't break anything
 for i in range(10):
-    image = misc.imread('1_Backdooring/testimages/' + str(i) + '.png')
+    image = io.imread('./testimages/' + str(i) + '.png')
     processedImage = np.zeros([1, 28, 28, 1])
     for yy in range(28):
         for xx in range(28):
@@ -60,4 +60,4 @@ for i in range(10):
         print('Digit ' + str(i) + ': Working!')
 
 # Saving the model
-model.save('1_Backdooring/backdoored_model.h5')
+model.save('./backdoored_model.h5')

--- a/2_ExtractingInformation/exercise.py
+++ b/2_ExtractingInformation/exercise.py
@@ -10,17 +10,17 @@ the example. Don't forget to save the model using model.save('model.h5')
 
 import keras
 import numpy as np
-from scipy import misc
+from skimage import io
 
 # Load the Image File
-image = misc.imread('2_ExtractingInformation/fake_id.png')
+image = io.imread('./fake_id.png')
 processedImage = np.zeros([1, 28, 28, 1])
 for yy in range(28):
     for xx in range(28):
         processedImage[0][xx][yy][0] = float(image[xx][yy]) / 255
 
 # Load the Model 
-model = keras.models.load_model('2_ExtractingInformation/model.h5')
+model = keras.models.load_model('./model.h5')
 
 # Run the Model and check what Digit was shown
 shownDigit = np.argmax(model.predict(processedImage))

--- a/2_ExtractingInformation/solution_2_0.py
+++ b/2_ExtractingInformation/solution_2_0.py
@@ -18,7 +18,7 @@ This sounds harder than it is:
 
 import keras
 import numpy as np
-from scipy import misc
+from skimage import io
 import matplotlib.pyplot as plt
 
 from keras.layers import Input, Dense, Reshape
@@ -28,7 +28,7 @@ from keras.optimizers import Adam
 
 
 # Load the target Model and make it untrainable 
-target_model = keras.models.load_model('2_ExtractingInformation/model.h5')
+target_model = keras.models.load_model('./model.h5')
 target_model.trainable = False
 
 # Create the fake-ID-generator network. It takes as input the same kind of
@@ -69,6 +69,6 @@ for x in range(total_epochs):
 fake_id = attack_model.predict(final_target)
 fake_id = np.asarray(fake_id[0])
 fake_id = np.reshape(fake_id, (28, 28))
-
-misc.toimage(fake_id, cmin=0.0, cmax=1.0).save('2_ExtractingInformation/fake_id.png')
+# The scipy.misc.toimage() function was deprecated in Scipy 1.0.0, and was completely removed in version 1.3.0.
+io.imsave('./fake_id.png', fake_id)
 

--- a/3_BruteForcing/exercise.py
+++ b/3_BruteForcing/exercise.py
@@ -14,7 +14,7 @@ import numpy as np
 from scipy import misc
 
 # Load the Model 
-model = keras.models.load_model('3_BruteForcing/model.h5')
+model = keras.models.load_model('./model.h5')
 
 runs = 1000
 

--- a/3_BruteForcing/solution_3_0.py
+++ b/3_BruteForcing/solution_3_0.py
@@ -8,10 +8,10 @@ The idea is to add some noise to our best-guess fake-ID.
 
 import keras
 import numpy as np
-from scipy import misc
+from skimage import io
 
 # Load the Model 
-model = keras.models.load_model('4_BruteForcing/model.h5')
+model = keras.models.load_model('./model.h5')
 
 runs = 1000
 max_intensity = 10
@@ -35,7 +35,7 @@ print('Pure Noise had a ' + str(successes) + ' / ' + str(runs) + ' success rate'
 print('Running Best Guess + Noise Test')
 
 # Best-Guess Fake ID
-image = misc.imread('4_BruteForcing/fake_id.png')
+image = io.imread('./fake_id.png')
 originalImage = np.zeros([1, 28, 28, 1])
 for yy in range(28):
     for xx in range(28):

--- a/4_NeuralOverflow/exercise.py
+++ b/4_NeuralOverflow/exercise.py
@@ -6,7 +6,7 @@ Please read the README.md for Exercise instructions!
 # ------------------
 
 from server import serverCheckInput
-from scipy import misc
+from skimage import io
 import numpy as np
 
 tests = 50

--- a/4_NeuralOverflow/server.py
+++ b/4_NeuralOverflow/server.py
@@ -7,7 +7,7 @@ import numpy as np
 
 def serverCheckInput(img):
     if serverCheckInput.model is None:
-        serverCheckInput.model = keras.models.load_model('4_NeuralOverflow/model.h5')
+        serverCheckInput.model = keras.models.load_model('./model.h5')
 
     prediction = serverCheckInput.model.predict(np.reshape(img, (1, 2, 2, 1)))
     if np.argmax(prediction[0]) == 0:

--- a/4_NeuralOverflow/solution_4_0.py
+++ b/4_NeuralOverflow/solution_4_0.py
@@ -1,5 +1,5 @@
 from server import serverCheckInput
-from scipy import misc
+from skimage import io
 import numpy as np
 
 # For completeness, here is an image that would have given access:

--- a/5_MalwareInjection/exercise.py
+++ b/5_MalwareInjection/exercise.py
@@ -13,8 +13,8 @@ import keras
 
 latent_dim = 256  # Latent dimensionality of the encoding space.
 
-input_token_index = np.load('5_MalwareInjection/input_tokens.npy').item()
-target_token_index = np.load('5_MalwareInjection/target_tokens.npy').item()
+input_token_index = np.load('./input_tokens.npy').item()
+target_token_index = np.load('./target_tokens.npy').item()
 
 num_encoder_tokens = len(input_token_index)
 num_decoder_tokens = len(target_token_index)
@@ -22,7 +22,7 @@ max_encoder_seq_length = 16
 max_decoder_seq_length = 53
 
 # Restore the model and construct the encoder and decoder.
-model = load_model('5_MalwareInjection\model.h5')
+model = load_model('./model.h5')
 
 encoder_inputs = model.input[0]   # input_1
 encoder_outputs, state_h_enc, state_c_enc = model.layers[2].output   # lstm_1

--- a/5_MalwareInjection/solution_5_0.py
+++ b/5_MalwareInjection/solution_5_0.py
@@ -14,8 +14,8 @@ import keras
 
 latent_dim = 256  # Latent dimensionality of the encoding space.
 
-input_token_index = np.load('5_MalwareInjection/input_tokens.npy').item()
-target_token_index = np.load('5_MalwareInjection/target_tokens.npy').item()
+input_token_index = np.load('./input_tokens.npy').item()
+target_token_index = np.load('./target_tokens.npy').item()
 
 num_encoder_tokens = len(input_token_index)
 num_decoder_tokens = len(target_token_index)
@@ -23,7 +23,7 @@ max_encoder_seq_length = 16
 max_decoder_seq_length = 53
 
 # Restore the model and construct the encoder and decoder.
-model = load_model('5_MalwareInjection\model.h5')
+model = load_model('./model.h5')
 
 
 

--- a/6_NeuralObfuscation/exercise.py
+++ b/6_NeuralObfuscation/exercise.py
@@ -15,7 +15,7 @@ import numpy as np
 
 latent_dim = 256  # Latent dimensionality of the encoding space.
 # Path to the data txt file on disk.
-data_path = '6_NeuralObfuscation/solution_data.txt'
+data_path = './solution_data.txt'
 
 # Vectorize the data.  We use the same approach as the training script.
 # NOTE: the data must be identical, in order for the character -> integer
@@ -62,7 +62,7 @@ for i, input_text in enumerate(input_texts):
         encoder_input_data[i, t, input_token_index[char]] = 1.
 
 # Restore the model and construct the encoder and decoder.
-model = load_model('6_NeuralObfuscation/solution_model.h5')
+model = load_model('./solution_model.h5')
 
 encoder_inputs = model.input[0]   # input_1
 encoder_outputs, state_h_enc, state_c_enc = model.layers[2].output   # lstm_1

--- a/6_NeuralObfuscation/solution_6_0.py
+++ b/6_NeuralObfuscation/solution_6_0.py
@@ -41,6 +41,6 @@ for i in range(total_size):
     elif i % 7 == 6:
         out_texts.append('Call\tping\n')
 
-with open('6_NeuralObfuscation/solution_data.txt', 'w') as f:
+with open('./solution_data.txt', 'w') as f:
     for item in out_texts:
         f.write(item)

--- a/6_NeuralObfuscation/train.py
+++ b/6_NeuralObfuscation/train.py
@@ -58,7 +58,7 @@ epochs = 100  # Number of epochs to train for.
 latent_dim = 256  # Latent dimensionality of the encoding space.
 
 # Path to the data txt file on disk.
-data_path = '6_NeuralObfuscation/solution_data.txt'
+data_path = './solution_data.txt'
 
 # Vectorize the data.
 input_texts = []
@@ -153,7 +153,7 @@ model.fit([encoder_input_data, decoder_input_data], decoder_target_data,
           epochs=epochs,
           validation_split=0.2)
 # Save model
-model.save('6_NeuralObfuscation/solution_model.h5')
+model.save('./solution_model.h5')
 
 # Next: inference mode (sampling).
 # Here's the drill:

--- a/7_BugHunter/solution_7_0.py
+++ b/7_BugHunter/solution_7_0.py
@@ -43,7 +43,7 @@ x_test = []
 x_test_real = []
 y_test = []
 
-f = open("7_BugHunter/train.txt", "r")
+f = open("./train.txt", "r")
 contents = f.readlines()
 for i, line in enumerate(contents):
     x_data, y_data = line.strip().split('\t')

--- a/8_GPUAttack/exercise.py
+++ b/8_GPUAttack/exercise.py
@@ -6,11 +6,11 @@ import pycuda.driver as cuda
 import pycuda.autoinit
 import numpy as np
 from pycuda.compiler import SourceModule
-from scipy import misc
+from skimage import io
 
 
 # Load Image
-image = misc.imread('8_GPUAttack/testimage.png')
+image = io.imread('./testimage.png')
 
 # Feel free to edit above this line, so you don't need to
 # draw everything in Photoshop or Paint... But nothing


### PR DESCRIPTION
This has an error happening when running this code: 
`**imread** is deprecated in SciPy 1.0.0, and will be removed in 1.2.0. Use **imageio.imread**`

So I think it's better to use skimage.io instead of scipy.misc,

and I also modified the path of the file in the directory to the current directory.

ex. `0_LastLayerAttack/model.h5` -> `./model.h5`, 
I prefer in this way, but I don't know if this will satisfy you.

